### PR TITLE
Add silent level support

### DIFF
--- a/multistream.js
+++ b/multistream.js
@@ -3,6 +3,7 @@
 var needsMetadata = Symbol.for('needsMetadata')
 
 var levels = {
+  silent: Infinity,
   fatal: 60,
   error: 50,
   warn: 40,

--- a/test/multistream.test.js
+++ b/test/multistream.test.js
@@ -15,7 +15,8 @@ test('sends to multiple streams using string levels', function (t) {
     {stream: stream},
     {level: 'debug', stream: stream},
     {level: 'trace', stream: stream},
-    {level: 'fatal', stream: stream}
+    {level: 'fatal', stream: stream},
+    {level: 'silent', stream: stream}
   ]
   var log = pino({
     level: 'trace'
@@ -23,6 +24,7 @@ test('sends to multiple streams using string levels', function (t) {
   log.info('info stream')
   log.debug('debug stream')
   log.fatal('fatal stream')
+  log.silent('silent stream')
   t.is(messageCount, 9)
   t.done()
 })


### PR DESCRIPTION
This change adds support for silent pino streams, supported natively in
pino, that print no messages.

This might seem like a silly log level, but is a great option for our test suite.