### PR TITLE
Simplify compareByLevel sorting function

### DIFF
--- a/multistream.js
+++ b/multistream.js
@@ -110,18 +110,10 @@ function multistream (streamsArray) {
 }
 
 function compareByLevel (a, b) {
-  if (a.level < b.level) {
-    return -1
-  } else if (a.level > b.level) {
-    return 1
+  if (a.level !== b.level) {
+    return a.level - b.level
   } else {
-    if (a.counter < b.counter) {
-      return -1
-    } else if (a.counter > b.counter) {
-      return 1
-    } else {
-      return 0
-    }
+    return a.counter - b.counter
   }
 }
 


### PR DESCRIPTION
The comparator used for `Array.prototype.sort` doesn't need to return only `1`, `-1` or `0` - it can be any value as long as it is less than, more than or equal to 0. This means to sort an array of numbers we only need to return `a - b`, and avoid two conditional statements. In this case we can simplify the code to just one conditional. 

Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#Description 