### PR TITLE
Pretty stream

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -131,6 +131,29 @@ The behavior of the get accessor changes if `{ bunyan: true }` is passed
 to pinoms. In that case, it implements the
 [`bunyan.level`](https://github.com/trentm/node-bunyan#levels) function.
 
+### pinoms.prettyStream({ [prettifier], [dest] })
+
+Manually create an output stream with a prettifier applied.
+
+```js
+var fs = require('fs');
+var pinoms = require('pino-multi-stream')
+
+var prettyStream = pinoms.prettyStream()
+var streams = [
+    {stream: fs.createWriteStream('my.log') },
+    {stream: prettyStream }
+]
+
+var logger = pinoms(pinoms.multistream(streams))
+
+logger.info("HELLO %s!", "World")
+```
+
+The options object may additionally contain a `prettifier` property to define which prettifier module to use. When not present, `prettifier` defaults to [`pino-pretty` ⇗](https://github.com/pinojs/pino-pretty) (must be installed as a separate dependency).
+
+The method may be passed an alternative write destination, but defaults to `process.stdout`.
+
 <a id="caveats"></a>
 ## Caveats
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const pino = require('pino')
+const getPrettyStream = require('pino/lib/tools').getPrettyStream
 const multistream = require('./multistream')
 const {
   streamSym,
@@ -85,5 +86,9 @@ function pinoMultiStream (opts, stream) {
 
 Object.assign(pinoMultiStream, pino)
 pinoMultiStream.multistream = multistream
+pinoMultiStream.prettyStream = (args = {}) => {
+  const { prettifier, dest = process.stdout } = args
+  return getPrettyStream({}, prettifier, dest)
+}
 
 module.exports = pinoMultiStream

--- a/test/wrapper.test.js
+++ b/test/wrapper.test.js
@@ -4,6 +4,7 @@ var writeStream = require('flush-write-stream')
 var pino = require('pino')
 var test = require('tap').test
 var pinoms = require('../')
+var { Writable } = require('stream')
 
 test('sends to multiple streams', function (t) {
   var messageCount = 0
@@ -253,4 +254,38 @@ test('correctly set level if passed with just one stream', function (t) {
   t.is(log.level, 'debug')
   t.is(messageCount, 3)
   t.done()
+})
+
+test('creates pretty write stream', async ({ is }) => {
+  const prettyStream = pinoms.prettyStream()
+  is(typeof prettyStream.write, 'function')
+})
+
+test('creates pretty write stream with default pino-pretty', async ({ is }) => {
+  const dest = new Writable({
+    objectMode: true,
+    write (formatted, enc) {
+      is(/^.*INFO.*foo\n$/.test(formatted), true)
+    }
+  })
+  const prettyStream = pinoms.prettyStream({ dest })
+  const log = pinoms({}, prettyStream)
+  log.info('foo')
+})
+
+test('creates pretty write stream with custom prettifier', async ({ is }) => {
+  const prettifier = function () {
+    return function () {
+      return 'FOO bar'
+    }
+  }
+  const dest = new Writable({
+    objectMode: true,
+    write (formatted, enc) {
+      is(formatted, 'FOO bar')
+    }
+  })
+  const prettyStream = pinoms.prettyStream({ prettifier, dest })
+  const log = pinoms({}, prettyStream)
+  log.info('foo')
 })

--- a/test/wrapper.test.js
+++ b/test/wrapper.test.js
@@ -256,16 +256,18 @@ test('correctly set level if passed with just one stream', function (t) {
   t.done()
 })
 
-test('creates pretty write stream', async ({ is }) => {
+test('creates pretty write stream', function (t) {
   const prettyStream = pinoms.prettyStream()
-  is(typeof prettyStream.write, 'function')
+  t.is(typeof prettyStream.write, 'function')
+  t.done()
 })
 
-test('creates pretty write stream with default pino-pretty', async ({ is }) => {
+test('creates pretty write stream with default pino-pretty', function (t) {
   const dest = new Writable({
     objectMode: true,
     write (formatted, enc) {
-      is(/^.*INFO.*foo\n$/.test(formatted), true)
+      t.is(/^.*INFO.*foo\n$/.test(formatted), true)
+      t.done()
     }
   })
   const prettyStream = pinoms.prettyStream({ dest })
@@ -273,7 +275,7 @@ test('creates pretty write stream with default pino-pretty', async ({ is }) => {
   log.info('foo')
 })
 
-test('creates pretty write stream with custom prettifier', async ({ is }) => {
+test('creates pretty write stream with custom prettifier', function (t) {
   const prettifier = function () {
     return function () {
       return 'FOO bar'
@@ -282,7 +284,8 @@ test('creates pretty write stream with custom prettifier', async ({ is }) => {
   const dest = new Writable({
     objectMode: true,
     write (formatted, enc) {
-      is(formatted, 'FOO bar')
+      t.is(formatted, 'FOO bar')
+      t.done()
     }
   })
   const prettyStream = pinoms.prettyStream({ prettifier, dest })


### PR DESCRIPTION
Replacement of PR pinojs/pino#666 (cc: @mcollina)

Direct implementation of functionality in `pino-multi-stream` to bypass core changes.