### PR TITLE
pretty-printing API fix

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -131,9 +131,9 @@ The behavior of the get accessor changes if `{ bunyan: true }` is passed
 to pinoms. In that case, it implements the
 [`bunyan.level`](https://github.com/trentm/node-bunyan#levels) function.
 
-### pinoms.prettyStream({ [opts],  [prettifier], [dest] })
+### pinoms.prettyStream({ [prettyPrint],  [prettifier], [dest] })
 
-_Note_: after 4.1.0, the list of parameters was changed, now it is the same as that of `pino` `prettyStream`.
+_Note_:  after 4.1.0 this `pino-multi-stream` function was changed according to that of `pino`, and after 4.2.0 its API (names of parameters and their options) are in conformity with API of `pino`/`pino-pretty`, as it is presented [here](https://getpino.io/#/docs/pretty). Those changes are related to pretty-printing options only.
 
 Manually create an output stream with a prettifier applied.
 
@@ -155,6 +155,24 @@ logger.info("HELLO %s!", "World")
 The options object may additionally contain a `prettifier` property to define which prettifier module to use. When not present, `prettifier` defaults to [`pino-pretty` ⇗](https://github.com/pinojs/pino-pretty) (must be installed as a separate dependency).
 
 The method may be passed an alternative write destination, but defaults to `process.stdout`.
+
+Prettifying options (after 4.2.0) are to be set like this:
+
+```javascript
+const prettyStream = pinoms.prettyStream(
+{ 
+ prettyPrint: 
+  { colorize: true,
+    translateTime: "SYS:standard",
+    ignore: "hostname,pid" // add 'time' to remove timestamp
+  },
+ prettifier: require('pino-pretty') // not required, just an example of setting prettifier
+    // as well it is possible to set destination option
+}
+);
+```
+
+
 
 <a id="caveats"></a>
 ## Caveats

--- a/index.js
+++ b/index.js
@@ -87,7 +87,8 @@ function pinoMultiStream (opts, stream) {
 Object.assign(pinoMultiStream, pino)
 pinoMultiStream.multistream = multistream
 pinoMultiStream.prettyStream = (args = {}) => {
-  const { prettyPrint = {}, prettifier, dest = process.stdout } = args
+  const prettyPrint = args.opts || args.prettyPrint
+  const { prettifier, dest = process.stdout } = args
   return getPrettyStream(prettyPrint, prettifier, dest)
 }
 

--- a/index.js
+++ b/index.js
@@ -87,8 +87,8 @@ function pinoMultiStream (opts, stream) {
 Object.assign(pinoMultiStream, pino)
 pinoMultiStream.multistream = multistream
 pinoMultiStream.prettyStream = (args = {}) => {
-  const { opts = {}, prettifier, dest = process.stdout } = args
-  return getPrettyStream(opts, prettifier, dest)
+  const { prettyPrint = {}, prettifier, dest = process.stdout } = args
+  return getPrettyStream(prettyPrint, prettifier, dest)
 }
 
 module.exports = pinoMultiStream

--- a/test/wrapper.test.js
+++ b/test/wrapper.test.js
@@ -303,8 +303,8 @@ test('creates pretty write stream with custom options for pino-pretty', function
       t.done()
     }
   })
-  const opts = { colorize: false, ignore: 'hostname,pid,time' }
-  const prettyStream = pinoms.prettyStream({ opts, dest })
+  const prettyPrint = { colorize: false, ignore: 'hostname,pid,time' }
+  const prettyStream = pinoms.prettyStream({ prettyPrint, dest })
   const log = pinoms({}, prettyStream)
   log.info('foo')
 })

--- a/test/wrapper.test.js
+++ b/test/wrapper.test.js
@@ -295,7 +295,7 @@ test('creates pretty write stream with custom prettifier', function (t) {
   log.info('foo')
 })
 
-test('creates pretty write stream with custom options for pino-pretty', function (t) {
+test('creates pretty write stream with custom options for pino-pretty, via prettyPrint (default)', function (t) {
   const dest = new Writable({
     objectMode: true,
     write (formatted, enc) {
@@ -305,6 +305,20 @@ test('creates pretty write stream with custom options for pino-pretty', function
   })
   const prettyPrint = { colorize: false, ignore: 'hostname,pid,time' }
   const prettyStream = pinoms.prettyStream({ prettyPrint, dest })
+  const log = pinoms({}, prettyStream)
+  log.info('foo')
+})
+
+test('creates pretty write stream with custom options for pino-pretty, via opts (obsolete)', function (t) {
+  const dest = new Writable({
+    objectMode: true,
+    write (formatted, enc) {
+      t.is(formatted, 'INFO : foo\n')
+      t.done()
+    }
+  })
+  const opts = { colorize: false, ignore: 'hostname,pid,time' }
+  const prettyStream = pinoms.prettyStream({ opts, dest })
   const log = pinoms({}, prettyStream)
   log.info('foo')
 })


### PR DESCRIPTION
Pretty-printing API unified with that of `pino`/`pino-pretty`, as it is presented [here](https://getpino.io/#/docs/pretty).