### PR TITLE
Added support to pass custom logLevels to `multistream()`

### DIFF
--- a/multistream.js
+++ b/multistream.js
@@ -2,7 +2,7 @@
 
 const metadata = Symbol.for('pino.metadata')
 
-const levels = {
+const defaultLevels = {
   silent: Infinity,
   fatal: 60,
   error: 50,
@@ -12,10 +12,11 @@ const levels = {
   trace: 10
 }
 
-function multistream (streamsArray) {
+function multistream (streamsArray, levels) {
   var counter = 0
 
   streamsArray = streamsArray || []
+  levels = levels || defaultLevels
 
   const res = {
     write,


### PR DESCRIPTION
It looks like the PR that fixes https://github.com/pinojs/pino-multi-stream/issues/23 was never merged:

https://github.com/pinojs/pino-multi-stream/pull/14

This fixes that.