### PR TITLE
fix: dedupe streams

### DIFF
--- a/multistream.js
+++ b/multistream.js
@@ -49,8 +49,8 @@ function multistream (streamsArray, opts) {
     var stream
     for (var i = 0; i < streams.length; i++) {
       dest = streams[i]
-      stream = dest.stream
       if (dest.level <= level) {
+        stream = dest.stream
         if (stream[metadata]) {
           const { lastTime, lastMsg, lastObj, lastLogger } = this
           stream.lastLevel = level

--- a/test/multistream.test.js
+++ b/test/multistream.test.js
@@ -327,7 +327,7 @@ test('one stream', function (t) {
 test('dedupe', function (t) {
   var messageCount = 0
   var stream1 = writeStream(function (data, enc, cb) {
-    messageCount += 1
+    messageCount -= 1
     cb()
   })
 
@@ -338,7 +338,8 @@ test('dedupe', function (t) {
 
   var streams = [
     {
-      stream: stream1
+      stream: stream1,
+      level: 'info'
     },
     {
       stream: stream2,
@@ -349,6 +350,8 @@ test('dedupe', function (t) {
   var log = pino({
     level: 'trace'
   }, multistream(streams, { dedupe: true }))
+  log.info('info stream')
+  log.fatal('fatal stream')
   log.fatal('fatal stream')
   t.is(messageCount, 1)
   t.done()


### PR DESCRIPTION
I just saw that when using new `dedupe` option all logs are sent to last level :disappointed: , this fixes the problem

I have also enhanced dedupe test to be sure this will not happen again

Sorry