### PR TITLE
Complement PR #34 with tests

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -65,13 +65,11 @@ the specifics for *pino-multi-stream*:
 
   1. If the `opts` parameter is a writable stream, then a real *pino*
      instance will be returned.
-
-  2. If the `opts` parameter is an object with a singular `stream` property
+2. If the `opts` parameter is an object with a singular `stream` property
      then a real *pino* instance will be returned. If there is also a plural
      `streams` property, the singular `stream` property takes precedence.
-
   3. If the `opts` parameter is an object with a plural `streams` property,
-     does not include a singluar `stream` property, and is an array, then
+   does not include a singluar `stream` property, and is an array, then
      a *pino-multi-stream* wrapped instance will be returned. Otherwise,
      `opts.streams` is treated a single stream and a real *pino* instance
      will be returned.
@@ -119,6 +117,8 @@ log.fatal('this will be written to /tmp/debug.stream.out, /tmp/info.stream.out a
 
 `opts` multistream options object. Available options are:
 
+* `levels`:  Pass custom log level definitions to the instance as an object.
+
 + `dedupe`: Set this to `true` to send logs only to the stream with the higher level. Default: `false`
 
     `dedupe` flag can be useful for example when using pino-multi-stream to redirect `error` logs to `process.stderr` and others to `process.stdout`:
@@ -131,10 +131,23 @@ log.fatal('this will be written to /tmp/debug.stream.out, /tmp/info.stream.out a
       {level: 'error', stream: process.stderr},
     ]
 
+    var opts = {
+        levels: {
+            silent: Infinity,
+            fatal: 60,
+        error: 50,
+            warn: 50,
+            info: 30,
+            debug: 20,
+            trace: 10
+        },
+        dedupe: true,
+    }
+
     var log = pino({
       level: 'debug' // this MUST be set at the lowest level of the
                     // destinations
-    }, multistream(streams, { dedupe: true }))
+    }, multistream(streams, opts))
 
     log.debug('this will be written ONLY to process.stdout')
     log.info('this will be written ONLY to process.stdout')
@@ -185,8 +198,8 @@ Prettifying options (after 4.2.0) are to be set like this:
 
 ```javascript
 const prettyStream = pinoms.prettyStream(
-{ 
- prettyPrint: 
+{
+ prettyPrint:
   { colorize: true,
     translateTime: "SYS:standard",
     ignore: "hostname,pid" // add 'time' to remove timestamp

--- a/Readme.md
+++ b/Readme.md
@@ -135,7 +135,7 @@ log.fatal('this will be written to /tmp/debug.stream.out, /tmp/info.stream.out a
         levels: {
             silent: Infinity,
             fatal: 60,
-        error: 50,
+            error: 50,
             warn: 50,
             info: 30,
             debug: 20,

--- a/multistream.js
+++ b/multistream.js
@@ -2,7 +2,7 @@
 
 const metadata = Symbol.for('pino.metadata')
 
-const levels = {
+var levels = {
   silent: Infinity,
   fatal: 60,
   error: 50,
@@ -16,8 +16,8 @@ function multistream (streamsArray, opts) {
   var counter = 0
 
   streamsArray = streamsArray || []
-
   opts = opts || { dedupe: false }
+  levels = opts.levels || levels
 
   const res = {
     write,

--- a/multistream.js
+++ b/multistream.js
@@ -2,7 +2,7 @@
 
 const metadata = Symbol.for('pino.metadata')
 
-var levels = {
+const defaultLevels = {
   silent: Infinity,
   fatal: 60,
   error: 50,
@@ -17,7 +17,11 @@ function multistream (streamsArray, opts) {
 
   streamsArray = streamsArray || []
   opts = opts || { dedupe: false }
-  levels = opts.levels || levels
+
+  var levels = defaultLevels
+  if (opts.levels && typeof opts.levels === 'object') {
+    levels = opts.levels
+  }
 
   const res = {
     write,

--- a/test/multistream.test.js
+++ b/test/multistream.test.js
@@ -28,6 +28,71 @@ test('sends to multiple streams using string levels', function (t) {
   t.done()
 })
 
+test('sends to multiple streams using custom levels', function (t) {
+  var messageCount = 0
+  var stream = writeStream(function (data, enc, cb) {
+    messageCount += 1
+    cb()
+  })
+  var streams = [
+    { stream: stream },
+    { level: 'debug', stream: stream },
+    { level: 'trace', stream: stream },
+    { level: 'fatal', stream: stream },
+    { level: 'silent', stream: stream }
+  ]
+  var log = pino({
+    level: 'trace'
+  }, multistream(streams))
+  log.info('info stream')
+  log.debug('debug stream')
+  log.fatal('fatal stream')
+  t.is(messageCount, 9)
+  t.done()
+})
+
+test('sends to multiple streams using optionally predefined levels', function (t) {
+  var messageCount = 0
+  var stream = writeStream(function (data, enc, cb) {
+    messageCount += 1
+    cb()
+  })
+  var opts = {
+    levels: {
+      silent: Infinity,
+      fatal: 60,
+      error: 50,
+      warn: 50,
+      info: 30,
+      debug: 20,
+      trace: 10
+    }
+  }
+  var streams = [
+    { stream: stream },
+    { level: 'trace', stream: stream },
+    { level: 'debug', stream: stream },
+    { level: 'info', stream: stream },
+    { level: 'warn', stream: stream },
+    { level: 'error', stream: stream },
+    { level: 'fatal', stream: stream },
+    { level: 'silent', stream: stream }
+  ]
+  var mstream = multistream(streams, opts)
+  var log = pino({
+    level: 'trace'
+  }, mstream)
+  log.trace('trace stream')
+  log.debug('debug stream')
+  log.info('info stream')
+  log.warn('warn stream')
+  log.error('error stream')
+  log.fatal('fatal stream')
+  log.silent('silent stream')
+  t.is(messageCount, 24)
+  t.done()
+})
+
 test('sends to multiple streams using number levels', function (t) {
   var messageCount = 0
   var stream = writeStream(function (data, enc, cb) {

--- a/test/wrapper.test.js
+++ b/test/wrapper.test.js
@@ -300,7 +300,7 @@ test('creates pretty write stream with custom options for pino-pretty, via prett
   const dest = new Writable({
     objectMode: true,
     write (formatted, enc) {
-      t.is(formatted, 'INFO : foo\n')
+      t.is(formatted, 'INFO\t: foo\n')
       t.done()
     }
   })
@@ -314,7 +314,7 @@ test('creates pretty write stream with custom options for pino-pretty, via opts 
   const dest = new Writable({
     objectMode: true,
     write (formatted, enc) {
-      t.is(formatted, 'INFO : foo\n')
+      t.is(formatted, 'INFO\t: foo\n')
       t.done()
     }
   })


### PR DESCRIPTION
**Description**
This PR was made to complement the missing tests for #34 and to complete the integration of custom log levels passed inside the existing `opts` object. In addition, some broken tests were fixed.

