### PR TITLE
Fixes crash with multiple streams and pretty print enabled

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,8 +30,11 @@ function pinoMultiStream (opts, stream) {
   return fixLevel(pino(toPino, multistream({ stream: iopts.stream, level: iopts.level }, opts)))
 
   function fixLevel (pino) {
-    pino.level = pino[streamSym].minLevel
-
+    if (pino[streamSym].minLevel) {
+      pino.level = pino[streamSym].minLevel
+    } else {
+      pino.level = pino[levelValSym]
+    }
     // internal knowledge dependency
     var setLevel = pino[setLevelSym]
 

--- a/test/multistream.test.js
+++ b/test/multistream.test.js
@@ -458,3 +458,22 @@ test('flushSync', function (t) {
     })()
   })
 })
+test('supports multiple streams with pretty print', function (t) {
+  let count = 0
+  const stream = writeStream(function (data, enc, cb) {
+    count++
+    t.isNot(data.toString().match(/INFO.*:.*pretty print/), null)
+    return cb()
+  })
+  t.plan(3)
+  const pinoms = require('../')
+  const logger = pinoms({
+    prettyPrint: true,
+    streams: [
+      { stream: stream },
+      { level: 'info', stream: stream }
+    ]
+  })
+  logger.info('pretty print')
+  t.equal(count, 2)
+})


### PR DESCRIPTION
Code reported in #69 makes the module crash.

My [comment](https://github.com/pinojs/pino-multi-stream/issues/69#issuecomment-910439913) proposes an alternative way, but anyway this PR will address that specific issue.

I ran `npx standard --fix` that's why there are also some linting fixes, sorry about that.

Fixes: #69 