### PR TITLE
Fixes linting with standard --fix

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -46,7 +46,7 @@ const blogFour = bunyan.createLogger({
 const max = 10
 const run = bench([
   function benchBunyanTen (cb) {
-    for (var i = 0; i < max; i++) {
+    for (let i = 0; i < max; i++) {
       blogTen.info('hello world')
       blogTen.debug('hello world')
       blogTen.trace('hello world')
@@ -56,7 +56,7 @@ const run = bench([
     setImmediate(cb)
   },
   function benchPinoMSTen (cb) {
-    for (var i = 0; i < max; i++) {
+    for (let i = 0; i < max; i++) {
       pinomsTen.info('hello world')
       pinomsTen.debug('hello world')
       pinomsTen.trace('hello world')
@@ -66,7 +66,7 @@ const run = bench([
     setImmediate(cb)
   },
   function benchBunyanFour (cb) {
-    for (var i = 0; i < max; i++) {
+    for (let i = 0; i < max; i++) {
       blogFour.info('hello world')
       blogFour.debug('hello world')
       blogFour.trace('hello world')
@@ -74,7 +74,7 @@ const run = bench([
     setImmediate(cb)
   },
   function benchPinoMSFour (cb) {
-    for (var i = 0; i < max; i++) {
+    for (let i = 0; i < max; i++) {
       pinomsFour.info('hello world')
       pinomsFour.debug('hello world')
       pinomsFour.trace('hello world')
@@ -82,13 +82,13 @@ const run = bench([
     setImmediate(cb)
   },
   function benchBunyanOne (cb) {
-    for (var i = 0; i < max; i++) {
+    for (let i = 0; i < max; i++) {
       blogOne.info('hello world')
     }
     setImmediate(cb)
   },
   function benchPinoMSOne (cb) {
-    for (var i = 0; i < max; i++) {
+    for (let i = 0; i < max; i++) {
       pinomsOne.info('hello world')
     }
     setImmediate(cb)

--- a/index.js
+++ b/index.js
@@ -33,10 +33,10 @@ function pinoMultiStream (opts, stream) {
     pino.level = pino[streamSym].minLevel
 
     // internal knowledge dependency
-    var setLevel = pino[setLevelSym]
+    const setLevel = pino[setLevelSym]
 
     pino[setLevelSym] = function (val) {
-      var prev = this[levelValSym]
+      const prev = this[levelValSym]
 
       // needed to support bunyan .level()
       if (typeof val === 'function') {
@@ -55,7 +55,7 @@ function pinoMultiStream (opts, stream) {
     if (isBunyan) {
       Object.defineProperty(pino, 'level', {
         get: function () {
-          var that = this
+          const that = this
           return function (val) {
             if (val !== undefined) {
               that[setLevelSym](val)

--- a/multistream.js
+++ b/multistream.js
@@ -13,12 +13,12 @@ const defaultLevels = {
 }
 
 function multistream (streamsArray, opts) {
-  var counter = 0
+  let counter = 0
 
   streamsArray = streamsArray || []
   opts = opts || { dedupe: false }
 
-  var levels = defaultLevels
+  let levels = defaultLevels
   if (opts.levels && typeof opts.levels === 'object') {
     levels = opts.levels
   }
@@ -48,11 +48,11 @@ function multistream (streamsArray, opts) {
 
   // we can exit early because the streams are ordered by level
   function write (data) {
-    var dest
+    let dest
     const level = this.lastLevel
     const { streams } = this
-    var stream
-    for (var i = 0; i < streams.length; i++) {
+    let stream
+    for (let i = 0; i < streams.length; i++) {
       dest = streams[i]
       if (dest.level <= level) {
         stream = dest.stream
@@ -110,9 +110,9 @@ function multistream (streamsArray, opts) {
   }
 
   function clone (level) {
-    var streams = new Array(this.streams.length)
+    const streams = new Array(this.streams.length)
 
-    for (var i = 0; i < streams.length; i++) {
+    for (let i = 0; i < streams.length; i++) {
       streams[i] = {
         level: level,
         stream: this.streams[i].stream

--- a/test/bunyan-level.test.js
+++ b/test/bunyan-level.test.js
@@ -1,19 +1,19 @@
 'use strict'
 
-var test = require('tap').test
-var os = require('os')
-var pino = require('../')
+const test = require('tap').test
+const os = require('os')
+const pino = require('../')
 
-var sink = require('./helper').sink
-var check = require('./helper').check
+const sink = require('./helper').sink
+const check = require('./helper').check
 
-var pid = process.pid
-var hostname = os.hostname()
+const pid = process.pid
+const hostname = os.hostname()
 
 function levelTest (name, level) {
   test(name + ' logs as ' + level, function (t) {
     t.plan(3)
-    var instance = pino({ bunyan: true }, sink(function (chunk, enc, cb) {
+    const instance = pino({ bunyan: true }, sink(function (chunk, enc, cb) {
       check(t, chunk, level, 'hello world')
     }))
 
@@ -24,7 +24,7 @@ function levelTest (name, level) {
 
   test(level + ' logs as ' + level, function (t) {
     t.plan(3)
-    var instance = pino({ bunyan: true }, sink(function (chunk, enc, cb) {
+    const instance = pino({ bunyan: true }, sink(function (chunk, enc, cb) {
       check(t, chunk, level, 'hello world')
     }))
 
@@ -35,7 +35,7 @@ function levelTest (name, level) {
 
   test('passing objects at level ' + name, function (t) {
     t.plan(3)
-    var instance = pino({ bunyan: true }, sink(function (chunk, enc, cb) {
+    const instance = pino({ bunyan: true }, sink(function (chunk, enc, cb) {
       t.ok(new Date(chunk.time) <= new Date(), 'time is greater than Date.now()')
       delete chunk.time
       t.deepEqual(chunk, {
@@ -53,7 +53,7 @@ function levelTest (name, level) {
 
   test('passing an object and a string at level ' + name, function (t) {
     t.plan(3)
-    var instance = pino({ bunyan: true }, sink(function (chunk, enc, cb) {
+    const instance = pino({ bunyan: true }, sink(function (chunk, enc, cb) {
       t.ok(new Date(chunk.time) <= new Date(), 'time is greater than Date.now()')
       delete chunk.time
       t.deepEqual(chunk, {
@@ -72,7 +72,7 @@ function levelTest (name, level) {
 
   test('formatting logs as ' + name, function (t) {
     t.plan(3)
-    var instance = pino({ bunyan: true }, sink(function (chunk, enc, cb) {
+    const instance = pino({ bunyan: true }, sink(function (chunk, enc, cb) {
       check(t, chunk, level, 'hello 42')
     }))
 
@@ -83,8 +83,8 @@ function levelTest (name, level) {
 
   test('passing error with a serializer at level ' + name, function (t) {
     t.plan(3)
-    var err = new Error('myerror')
-    var instance = pino({
+    const err = new Error('myerror')
+    const instance = pino({
       bunyan: true,
       serializers: {
         err: pino.stdSerializers.err
@@ -112,7 +112,7 @@ function levelTest (name, level) {
 
   test('child logger for level ' + name, function (t) {
     t.plan(3)
-    var instance = pino({ bunyan: true }, sink(function (chunk, enc, cb) {
+    const instance = pino({ bunyan: true }, sink(function (chunk, enc, cb) {
       t.ok(new Date(chunk.time) <= new Date(), 'time is greater than Date.now()')
       delete chunk.time
       t.deepEqual(chunk, {
@@ -125,7 +125,7 @@ function levelTest (name, level) {
     }))
 
     instance.level(name)
-    var child = instance.child({
+    const child = instance.child({
       hello: 'world'
     })
     child[name]('hello world')

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,13 +1,13 @@
 'use strict'
 
-var writeStream = require('flush-write-stream')
-var split = require('split2')
-var os = require('os')
-var pid = process.pid
-var hostname = os.hostname()
+const writeStream = require('flush-write-stream')
+const split = require('split2')
+const os = require('os')
+const pid = process.pid
+const hostname = os.hostname()
 
 function sink (func) {
-  var result = split(JSON.parse)
+  const result = split(JSON.parse)
   result.pipe(writeStream.obj(func))
   return result
 }

--- a/test/level.test.js
+++ b/test/level.test.js
@@ -1,19 +1,19 @@
 'use strict'
 
-var test = require('tap').test
-var os = require('os')
-var pino = require('../')
+const test = require('tap').test
+const os = require('os')
+const pino = require('../')
 
-var sink = require('./helper').sink
-var check = require('./helper').check
+const sink = require('./helper').sink
+const check = require('./helper').check
 
-var pid = process.pid
-var hostname = os.hostname()
+const pid = process.pid
+const hostname = os.hostname()
 
 function levelTest (name, level) {
   test(name + ' logs as ' + level, function (t) {
     t.plan(2)
-    var instance = pino(sink(function (chunk, enc, cb) {
+    const instance = pino(sink(function (chunk, enc, cb) {
       check(t, chunk, level, 'hello world')
     }))
 
@@ -23,7 +23,7 @@ function levelTest (name, level) {
 
   test('passing objects at level ' + name, function (t) {
     t.plan(2)
-    var instance = pino(sink(function (chunk, enc, cb) {
+    const instance = pino(sink(function (chunk, enc, cb) {
       t.ok(new Date(chunk.time) <= new Date(), 'time is greater than Date.now()')
       delete chunk.time
       t.deepEqual(chunk, {
@@ -40,7 +40,7 @@ function levelTest (name, level) {
 
   test('passing an object and a string at level ' + name, function (t) {
     t.plan(2)
-    var instance = pino(sink(function (chunk, enc, cb) {
+    const instance = pino(sink(function (chunk, enc, cb) {
       t.ok(new Date(chunk.time) <= new Date(), 'time is greater than Date.now()')
       delete chunk.time
       t.deepEqual(chunk, {
@@ -58,7 +58,7 @@ function levelTest (name, level) {
 
   test('formatting logs as ' + name, function (t) {
     t.plan(2)
-    var instance = pino(sink(function (chunk, enc, cb) {
+    const instance = pino(sink(function (chunk, enc, cb) {
       check(t, chunk, level, 'hello 42')
     }))
 
@@ -68,8 +68,8 @@ function levelTest (name, level) {
 
   test('passing error with a serializer at level ' + name, function (t) {
     t.plan(2)
-    var err = new Error('myerror')
-    var instance = pino({
+    const err = new Error('myerror')
+    const instance = pino({
       serializers: {
         err: pino.stdSerializers.err
       }
@@ -95,7 +95,7 @@ function levelTest (name, level) {
 
   test('child logger for level ' + name, function (t) {
     t.plan(2)
-    var instance = pino(sink(function (chunk, enc, cb) {
+    const instance = pino(sink(function (chunk, enc, cb) {
       t.ok(new Date(chunk.time) <= new Date(), 'time is greater than Date.now()')
       delete chunk.time
       t.deepEqual(chunk, {
@@ -108,14 +108,14 @@ function levelTest (name, level) {
     }))
 
     instance.level = name
-    var child = instance.child({
+    const child = instance.child({
       hello: 'world'
     })
     child[name]('hello world')
   })
 
   test('child logger for level ' + name + ' does not change parent level', function (t) {
-    var instance = pino({
+    const instance = pino({
       customLevels: {
         buu: level + 1
       }
@@ -125,7 +125,7 @@ function levelTest (name, level) {
 
     instance.level = level + 1
 
-    var child = instance.child({
+    const child = instance.child({
       hello: 'world'
     })
 

--- a/test/multistream.test.js
+++ b/test/multistream.test.js
@@ -1,27 +1,27 @@
 'use strict'
 
-var writeStream = require('flush-write-stream')
+const writeStream = require('flush-write-stream')
 const { join } = require('path')
 const { readFileSync } = require('fs')
 const os = require('os')
-var test = require('tap').test
-var pino = require('pino')
-var multistream = require('../').multistream
+const test = require('tap').test
+const pino = require('pino')
+const multistream = require('../').multistream
 
 test('sends to multiple streams using string levels', function (t) {
-  var messageCount = 0
-  var stream = writeStream(function (data, enc, cb) {
+  let messageCount = 0
+  const stream = writeStream(function (data, enc, cb) {
     messageCount += 1
     cb()
   })
-  var streams = [
+  const streams = [
     { stream: stream },
     { level: 'debug', stream: stream },
     { level: 'trace', stream: stream },
     { level: 'fatal', stream: stream },
     { level: 'silent', stream: stream }
   ]
-  var log = pino({
+  const log = pino({
     level: 'trace'
   }, multistream(streams))
   log.info('info stream')
@@ -32,19 +32,19 @@ test('sends to multiple streams using string levels', function (t) {
 })
 
 test('sends to multiple streams using custom levels', function (t) {
-  var messageCount = 0
-  var stream = writeStream(function (data, enc, cb) {
+  let messageCount = 0
+  const stream = writeStream(function (data, enc, cb) {
     messageCount += 1
     cb()
   })
-  var streams = [
+  const streams = [
     { stream: stream },
     { level: 'debug', stream: stream },
     { level: 'trace', stream: stream },
     { level: 'fatal', stream: stream },
     { level: 'silent', stream: stream }
   ]
-  var log = pino({
+  const log = pino({
     level: 'trace'
   }, multistream(streams))
   log.info('info stream')
@@ -55,12 +55,12 @@ test('sends to multiple streams using custom levels', function (t) {
 })
 
 test('sends to multiple streams using optionally predefined levels', function (t) {
-  var messageCount = 0
-  var stream = writeStream(function (data, enc, cb) {
+  let messageCount = 0
+  const stream = writeStream(function (data, enc, cb) {
     messageCount += 1
     cb()
   })
-  var opts = {
+  const opts = {
     levels: {
       silent: Infinity,
       fatal: 60,
@@ -71,7 +71,7 @@ test('sends to multiple streams using optionally predefined levels', function (t
       trace: 10
     }
   }
-  var streams = [
+  const streams = [
     { stream: stream },
     { level: 'trace', stream: stream },
     { level: 'debug', stream: stream },
@@ -81,8 +81,8 @@ test('sends to multiple streams using optionally predefined levels', function (t
     { level: 'fatal', stream: stream },
     { level: 'silent', stream: stream }
   ]
-  var mstream = multistream(streams, opts)
-  var log = pino({
+  const mstream = multistream(streams, opts)
+  const log = pino({
     level: 'trace'
   }, mstream)
   log.trace('trace stream')
@@ -97,17 +97,17 @@ test('sends to multiple streams using optionally predefined levels', function (t
 })
 
 test('sends to multiple streams using number levels', function (t) {
-  var messageCount = 0
-  var stream = writeStream(function (data, enc, cb) {
+  let messageCount = 0
+  const stream = writeStream(function (data, enc, cb) {
     messageCount += 1
     cb()
   })
-  var streams = [
+  const streams = [
     { stream: stream },
     { level: 20, stream: stream },
     { level: 60, stream: stream }
   ]
-  var log = pino({
+  const log = pino({
     level: 'debug'
   }, multistream(streams))
   log.info('info stream')
@@ -118,68 +118,68 @@ test('sends to multiple streams using number levels', function (t) {
 })
 
 test('level include higher levels', function (t) {
-  var messageCount = 0
-  var stream = writeStream(function (data, enc, cb) {
+  let messageCount = 0
+  const stream = writeStream(function (data, enc, cb) {
     messageCount += 1
     cb()
   })
-  var log = pino({}, multistream([{ level: 'info', stream: stream }]))
+  const log = pino({}, multistream([{ level: 'info', stream: stream }]))
   log.fatal('message')
   t.is(messageCount, 1)
   t.done()
 })
 
 test('supports multiple arguments', function (t) {
-  var messages = []
-  var stream = writeStream(function (data, enc, cb) {
+  const messages = []
+  const stream = writeStream(function (data, enc, cb) {
     messages.push(JSON.parse(data))
     if (messages.length === 2) {
-      var msg1 = messages[0]
+      const msg1 = messages[0]
       t.is(msg1.msg, 'foo bar baz foobar')
 
-      var msg2 = messages[1]
+      const msg2 = messages[1]
       t.is(msg2.msg, 'foo bar baz foobar barfoo foofoo')
 
       t.done()
     }
     cb()
   })
-  var log = pino({}, multistream({ stream }))
+  const log = pino({}, multistream({ stream }))
   log.info('%s %s %s %s', 'foo', 'bar', 'baz', 'foobar') // apply not invoked
   log.info('%s %s %s %s %s %s', 'foo', 'bar', 'baz', 'foobar', 'barfoo', 'foofoo') // apply invoked
 })
 
 test('supports children', function (t) {
-  var stream = writeStream(function (data, enc, cb) {
-    var input = JSON.parse(data)
+  const stream = writeStream(function (data, enc, cb) {
+    const input = JSON.parse(data)
     t.is(input.msg, 'child stream')
     t.is(input.child, 'one')
     t.done()
     cb()
   })
-  var streams = [
+  const streams = [
     { stream: stream }
   ]
-  var log = pino({}, multistream(streams)).child({ child: 'one' })
+  const log = pino({}, multistream(streams)).child({ child: 'one' })
   log.info('child stream')
 })
 
 test('supports grandchildren', function (t) {
-  var messages = []
-  var stream = writeStream(function (data, enc, cb) {
+  const messages = []
+  const stream = writeStream(function (data, enc, cb) {
     messages.push(JSON.parse(data))
     if (messages.length === 3) {
-      var msg1 = messages[0]
+      const msg1 = messages[0]
       t.is(msg1.msg, 'grandchild stream')
       t.is(msg1.child, 'one')
       t.is(msg1.grandchild, 'two')
 
-      var msg2 = messages[1]
+      const msg2 = messages[1]
       t.is(msg2.msg, 'grandchild stream')
       t.is(msg2.child, 'one')
       t.is(msg2.grandchild, 'two')
 
-      var msg3 = messages[2]
+      const msg3 = messages[2]
       t.is(msg3.msg, 'debug grandchild')
       t.is(msg3.child, 'one')
       t.is(msg3.grandchild, 'two')
@@ -188,11 +188,11 @@ test('supports grandchildren', function (t) {
     }
     cb()
   })
-  var streams = [
+  const streams = [
     { stream: stream },
     { level: 'debug', stream: stream }
   ]
-  var log = pino({
+  const log = pino({
     level: 'debug'
   }, multistream(streams)).child({ child: 'one' }).child({ grandchild: 'two' })
   log.info('grandchild stream')
@@ -200,11 +200,11 @@ test('supports grandchildren', function (t) {
 })
 
 test('supports custom levels', function (t) {
-  var stream = writeStream(function (data, enc, cb) {
+  const stream = writeStream(function (data, enc, cb) {
     t.is(JSON.parse(data).msg, 'bar')
     t.done()
   })
-  var log = pino({
+  const log = pino({
     customLevels: {
       foo: 35
     }
@@ -213,19 +213,19 @@ test('supports custom levels', function (t) {
 })
 
 test('supports pretty print', function (t) {
-  var stream = writeStream(function (data, enc, cb) {
+  const stream = writeStream(function (data, enc, cb) {
     t.isNot(data.toString().match(/INFO.*: pretty print/), null)
     t.done()
     cb()
   })
-  var outStream = pino({
+  const outStream = pino({
     prettyPrint: {
       levelFirst: true,
       colorize: false
     }
   }, stream)
 
-  var log = pino({
+  const log = pino({
     level: 'debug',
     name: 'helloName'
   }, multistream([
@@ -236,31 +236,31 @@ test('supports pretty print', function (t) {
 })
 
 test('children support custom levels', function (t) {
-  var stream = writeStream(function (data, enc, cb) {
+  const stream = writeStream(function (data, enc, cb) {
     t.is(JSON.parse(data).msg, 'bar')
     t.done()
   })
-  var parent = pino({
+  const parent = pino({
     customLevels: {
       foo: 35
     }
   }, multistream([{ level: 35, stream: stream }]))
-  var child = parent.child({ child: 'yes' })
+  const child = parent.child({ child: 'yes' })
   child.foo('bar')
 })
 
 test('levelVal ovverides level', function (t) {
-  var messageCount = 0
-  var stream = writeStream(function (data, enc, cb) {
+  let messageCount = 0
+  const stream = writeStream(function (data, enc, cb) {
     messageCount += 1
     cb()
   })
-  var streams = [
+  const streams = [
     { stream: stream },
     { level: 'blabla', levelVal: 15, stream: stream },
     { level: 60, stream: stream }
   ]
-  var log = pino({
+  const log = pino({
     level: 'debug'
   }, multistream(streams))
   log.info('info stream')
@@ -272,7 +272,7 @@ test('levelVal ovverides level', function (t) {
 
 test('forwards metadata', function (t) {
   t.plan(3)
-  var streams = [
+  const streams = [
     {
       stream: {
         [Symbol.for('pino.metadata')]: true,
@@ -285,7 +285,7 @@ test('forwards metadata', function (t) {
     }
   ]
 
-  var log = pino({
+  const log = pino({
     level: 'debug'
   }, multistream(streams))
 
@@ -295,7 +295,7 @@ test('forwards metadata', function (t) {
 
 test('forward name', function (t) {
   t.plan(2)
-  var streams = [
+  const streams = [
     {
       stream: {
         [Symbol.for('pino.metadata')]: true,
@@ -308,7 +308,7 @@ test('forward name', function (t) {
     }
   ]
 
-  var log = pino({
+  const log = pino({
     level: 'debug',
     name: 'helloName'
   }, multistream(streams))
@@ -319,7 +319,7 @@ test('forward name', function (t) {
 
 test('forward name with child', function (t) {
   t.plan(3)
-  var streams = [
+  const streams = [
     {
       stream: {
         write (chunk) {
@@ -332,7 +332,7 @@ test('forward name with child', function (t) {
     }
   ]
 
-  var log = pino({
+  const log = pino({
     level: 'debug',
     name: 'helloName'
   }, multistream(streams)).child({ component: 'aComponent' })
@@ -342,19 +342,19 @@ test('forward name with child', function (t) {
 })
 
 test('clone generates a new multistream with all stream at the same level', function (t) {
-  var messageCount = 0
-  var stream = writeStream(function (data, enc, cb) {
+  let messageCount = 0
+  const stream = writeStream(function (data, enc, cb) {
     messageCount += 1
     cb()
   })
-  var streams = [
+  const streams = [
     { stream: stream },
     { level: 'debug', stream: stream },
     { level: 'trace', stream: stream },
     { level: 'fatal', stream: stream }
   ]
-  var ms = multistream(streams)
-  var clone = ms.clone(30)
+  const ms = multistream(streams)
+  const clone = ms.clone(30)
 
   t.notEqual(clone, ms)
 
@@ -364,7 +364,7 @@ test('clone generates a new multistream with all stream at the same level', func
     t.equal(s.level, 30)
   })
 
-  var log = pino({
+  const log = pino({
     level: 'trace'
   }, clone)
 
@@ -377,12 +377,12 @@ test('clone generates a new multistream with all stream at the same level', func
 })
 
 test('one stream', function (t) {
-  var messageCount = 0
-  var stream = writeStream(function (data, enc, cb) {
+  let messageCount = 0
+  const stream = writeStream(function (data, enc, cb) {
     messageCount += 1
     cb()
   })
-  var log = pino({
+  const log = pino({
     level: 'trace'
   }, multistream({ stream, level: 'fatal' }))
   log.info('info stream')
@@ -393,18 +393,18 @@ test('one stream', function (t) {
 })
 
 test('dedupe', function (t) {
-  var messageCount = 0
-  var stream1 = writeStream(function (data, enc, cb) {
+  let messageCount = 0
+  const stream1 = writeStream(function (data, enc, cb) {
     messageCount -= 1
     cb()
   })
 
-  var stream2 = writeStream(function (data, enc, cb) {
+  const stream2 = writeStream(function (data, enc, cb) {
     messageCount += 1
     cb()
   })
 
-  var streams = [
+  const streams = [
     {
       stream: stream1,
       level: 'info'
@@ -415,7 +415,7 @@ test('dedupe', function (t) {
     }
   ]
 
-  var log = pino({
+  const log = pino({
     level: 'trace'
   }, multistream(streams, { dedupe: true }))
   log.info('info stream')
@@ -426,7 +426,7 @@ test('dedupe', function (t) {
 })
 
 test('no stream', function (t) {
-  var log = pino({
+  const log = pino({
     level: 'trace'
   }, multistream())
   log.info('info stream')

--- a/test/wrapper.test.js
+++ b/test/wrapper.test.js
@@ -1,24 +1,24 @@
 'use strict'
 
-var writeStream = require('flush-write-stream')
-var pino = require('pino')
-var test = require('tap').test
-var pinoms = require('../')
-var { Writable } = require('stream')
-var strip = require('strip-ansi')
+const writeStream = require('flush-write-stream')
+const pino = require('pino')
+const test = require('tap').test
+const pinoms = require('../')
+const { Writable } = require('stream')
+const strip = require('strip-ansi')
 
 test('sends to multiple streams', function (t) {
-  var messageCount = 0
-  var stream = writeStream(function (data, enc, cb) {
+  let messageCount = 0
+  const stream = writeStream(function (data, enc, cb) {
     messageCount += 1
     cb()
   })
-  var streams = [
+  const streams = [
     { stream: stream },
     { level: 'debug', stream: stream },
     { level: 'fatal', stream: stream }
   ]
-  var log = pinoms({ streams: streams })
+  const log = pinoms({ streams: streams })
   log.info('info stream')
   log.debug('debug stream')
   log.fatal('fatal stream')
@@ -27,68 +27,68 @@ test('sends to multiple streams', function (t) {
 })
 
 test('level include higher levels', function (t) {
-  var messageCount = 0
-  var stream = writeStream(function (data, enc, cb) {
+  let messageCount = 0
+  const stream = writeStream(function (data, enc, cb) {
     messageCount += 1
     cb()
   })
-  var log = pinoms({ streams: [{ level: 'info', stream: stream }] })
+  const log = pinoms({ streams: [{ level: 'info', stream: stream }] })
   log.fatal('message')
   t.is(messageCount, 1)
   t.done()
 })
 
 test('supports multiple arguments', function (t) {
-  var messages = []
-  var stream = writeStream(function (data, enc, cb) {
+  const messages = []
+  const stream = writeStream(function (data, enc, cb) {
     messages.push(JSON.parse(data))
     if (messages.length === 2) {
-      var msg1 = messages[0]
+      const msg1 = messages[0]
       t.is(msg1.msg, 'foo bar baz foobar')
 
-      var msg2 = messages[1]
+      const msg2 = messages[1]
       t.is(msg2.msg, 'foo bar baz foobar barfoo foofoo')
 
       t.done()
     }
     cb()
   })
-  var log = pinoms({ streams: stream })
+  const log = pinoms({ streams: stream })
   log.info('%s %s %s %s', 'foo', 'bar', 'baz', 'foobar') // apply not invoked
   log.info('%s %s %s %s %s %s', 'foo', 'bar', 'baz', 'foobar', 'barfoo', 'foofoo') // apply invoked
 })
 
 test('supports children', function (t) {
-  var stream = writeStream(function (data, enc, cb) {
-    var input = JSON.parse(data)
+  const stream = writeStream(function (data, enc, cb) {
+    const input = JSON.parse(data)
     t.is(input.msg, 'child stream')
     t.is(input.child, 'one')
     t.done()
     cb()
   })
-  var streams = [
+  const streams = [
     { stream: stream }
   ]
-  var log = pinoms({ streams: streams }).child({ child: 'one' })
+  const log = pinoms({ streams: streams }).child({ child: 'one' })
   log.info('child stream')
 })
 
 test('supports grandchildren', function (t) {
-  var messages = []
-  var stream = writeStream(function (data, enc, cb) {
+  const messages = []
+  const stream = writeStream(function (data, enc, cb) {
     messages.push(JSON.parse(data))
     if (messages.length === 3) {
-      var msg1 = messages[0]
+      const msg1 = messages[0]
       t.is(msg1.msg, 'grandchild stream')
       t.is(msg1.child, 'one')
       t.is(msg1.grandchild, 'two')
 
-      var msg2 = messages[1]
+      const msg2 = messages[1]
       t.is(msg2.msg, 'grandchild stream')
       t.is(msg2.child, 'one')
       t.is(msg2.grandchild, 'two')
 
-      var msg3 = messages[2]
+      const msg3 = messages[2]
       t.is(msg3.msg, 'debug grandchild')
       t.is(msg3.child, 'one')
       t.is(msg3.grandchild, 'two')
@@ -97,21 +97,21 @@ test('supports grandchildren', function (t) {
     }
     cb()
   })
-  var streams = [
+  const streams = [
     { stream: stream },
     { level: 'debug', stream: stream }
   ]
-  var log = pinoms({ streams: streams }).child({ child: 'one' }).child({ grandchild: 'two' })
+  const log = pinoms({ streams: streams }).child({ child: 'one' }).child({ grandchild: 'two' })
   log.info('grandchild stream')
   log.debug('debug grandchild')
 })
 
 test('supports custom levels', function (t) {
-  var stream = writeStream(function (data, enc, cb) {
+  const stream = writeStream(function (data, enc, cb) {
     t.is(JSON.parse(data).msg, 'bar')
     t.done()
   })
-  var log = pinoms({
+  const log = pinoms({
     customLevels: {
       foo: 35
     },
@@ -125,11 +125,11 @@ test('supports custom levels', function (t) {
 })
 
 test('children support custom levels', function (t) {
-  var stream = writeStream(function (data, enc, cb) {
+  const stream = writeStream(function (data, enc, cb) {
     t.is(JSON.parse(data).msg, 'bar')
     t.done()
   })
-  var parent = pinoms({
+  const parent = pinoms({
     customLevels: {
       foo: 35
     },
@@ -139,12 +139,12 @@ test('children support custom levels', function (t) {
     }
     ]
   })
-  var child = parent.child({ child: 'yes' })
+  const child = parent.child({ child: 'yes' })
   child.foo('bar')
 })
 
 test('supports empty constructor arguments', function (t) {
-  var log = pinoms()
+  const log = pinoms()
   t.is(typeof log.info, 'function')
   t.done()
 })
@@ -185,19 +185,19 @@ test('exposes pino.symbols', function (t) {
 })
 
 test('forwards name', function (t) {
-  var messageCount = 0
-  var stream = writeStream(function (data, enc, cb) {
+  let messageCount = 0
+  const stream = writeStream(function (data, enc, cb) {
     messageCount += 1
-    var line = JSON.parse(data)
+    const line = JSON.parse(data)
     t.equal(line.name, 'system')
     cb()
   })
-  var streams = [
+  const streams = [
     { stream: stream },
     { level: 'debug', stream: stream },
     { level: 'fatal', stream: stream }
   ]
-  var log = pinoms({ name: 'system', streams: streams })
+  const log = pinoms({ name: 'system', streams: streams })
   log.info('info stream')
   log.debug('debug stream')
   log.fatal('fatal stream')
@@ -206,19 +206,19 @@ test('forwards name', function (t) {
 })
 
 test('forwards name via child', function (t) {
-  var messageCount = 0
-  var stream = writeStream(function (data, enc, cb) {
+  let messageCount = 0
+  const stream = writeStream(function (data, enc, cb) {
     messageCount += 1
-    var line = JSON.parse(data)
+    const line = JSON.parse(data)
     t.equal(line.name, 'system')
     cb()
   })
-  var streams = [
+  const streams = [
     { stream: stream },
     { level: 'debug', stream: stream },
     { level: 'fatal', stream: stream }
   ]
-  var log = pinoms({ streams: streams }).child({ name: 'system' })
+  const log = pinoms({ streams: streams }).child({ name: 'system' })
   log.info('info stream')
   log.debug('debug stream')
   log.fatal('fatal stream')
@@ -227,14 +227,14 @@ test('forwards name via child', function (t) {
 })
 
 test('forwards name without streams', function (t) {
-  var messageCount = 0
-  var stream = writeStream(function (data, enc, cb) {
+  let messageCount = 0
+  const stream = writeStream(function (data, enc, cb) {
     messageCount += 1
-    var line = JSON.parse(data)
+    const line = JSON.parse(data)
     t.equal(line.name, 'system')
     cb()
   })
-  var log = pinoms({ name: 'system', stream: stream })
+  const log = pinoms({ name: 'system', stream: stream })
   log.info('info stream')
   log.debug('debug stream')
   log.fatal('fatal stream')
@@ -243,14 +243,14 @@ test('forwards name without streams', function (t) {
 })
 
 test('correctly set level if passed with just one stream', function (t) {
-  var messageCount = 0
-  var stream = writeStream(function (data, enc, cb) {
+  let messageCount = 0
+  const stream = writeStream(function (data, enc, cb) {
     messageCount += 1
-    var line = JSON.parse(data)
+    const line = JSON.parse(data)
     t.equal(line.name, 'system')
     cb()
   })
-  var log = pinoms({ name: 'system', level: 'debug', stream: stream })
+  const log = pinoms({ name: 'system', level: 'debug', stream: stream })
   log.info('info stream')
   log.debug('debug stream')
   log.fatal('fatal stream')
@@ -325,17 +325,17 @@ test('creates pretty write stream with custom options for pino-pretty, via opts 
 })
 
 test('custom levels', function (t) {
-  var messageCount = 0
-  var stream = writeStream(function (data, enc, cb) {
+  let messageCount = 0
+  const stream = writeStream(function (data, enc, cb) {
     messageCount += 1
     cb()
   })
-  var streams = [
+  const streams = [
     { stream: stream },
     { level: 15, stream: stream },
     { level: 60, stream: stream }
   ]
-  var log = pinoms({
+  const log = pinoms({
     level: 'debug',
     customLevels: {
       blabla: 15


### PR DESCRIPTION
Removes hundreds of warnings from `npx standard` command which is included in `npm test` script.

Will remove these changes from #70 